### PR TITLE
fix: Add null safety to formatStatus() — emergency fix

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -60,6 +60,7 @@ const STATUS_BADGES = {
 };
 
 function formatStatus(status) {
+  if (!status) return { color: '#6b7280', label: 'Unknown', icon: '?' };
   const key = status.toLowerCase();  // crashes when status is null from legacy rows
   return STATUS_BADGES[key] || { color: '#6b7280', label: status, icon: '?' };
 }


### PR DESCRIPTION
## Emergency Fix — SEV-1 Production Incident

### Problem
`formatStatus()` crashes with `TypeError: Cannot read properties of null` when processing legacy orders with NULL status.

### Root Cause  
PR #1 removed `WHERE o.status IS NOT NULL`. Production has legacy orders with NULL status from 2023 migration.

### Fix
```js
if (!status) return { color: "#6b7280", label: "Unknown", icon: "?" };
```

### Testing
- ✅ Staging: all endpoints healthy
- ✅ Null status rows return "Unknown" badge instead of crashing

Fixes #2

> 🤖 Created automatically by Dave SRE